### PR TITLE
Follow App Store Connect API pagination in data source list reads

### DIFF
--- a/internal/provider/certificate_data_source.go
+++ b/internal/provider/certificate_data_source.go
@@ -235,6 +235,7 @@ func (d *CertificateDataSource) Read(ctx context.Context, req datasource.ReadReq
 		// Build query parameters
 		query := make(map[string]string)
 		query["include"] = "passTypeId"
+		query["limit"] = "200" // Maximum page size allowed by the API
 
 		if !filter.CertificateType.IsNull() {
 			query["filter[certificateType]"] = filter.CertificateType.ValueString()
@@ -245,8 +246,10 @@ func (d *CertificateDataSource) Read(ctx context.Context, req datasource.ReadReq
 			"serial_number":    filter.SerialNumber.ValueString(),
 		})
 
-		// Make the API request to list certificates
-		apiResp, err := d.client.Do(ctx, Request{
+		// Make the API request to list certificates, following pagination so a
+		// serial-number match on a later page is not missed and reported as
+		// "not found".
+		apiResp, err := d.client.DoList(ctx, Request{
 			Method:   http.MethodGet,
 			Endpoint: "/certificates",
 			Query:    query,

--- a/internal/provider/certificates_data_source.go
+++ b/internal/provider/certificates_data_source.go
@@ -211,8 +211,9 @@ func (d *CertificatesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		tflog.Debug(ctx, "Fetching all Certificates")
 	}
 
-	// Make the API request
-	apiResp, err := d.client.Do(ctx, Request{
+	// Make the API request, following pagination so certificates past the
+	// first page are not silently dropped.
+	apiResp, err := d.client.DoList(ctx, Request{
 		Method:   http.MethodGet,
 		Endpoint: "/certificates",
 		Query:    query,

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -32,6 +32,12 @@ const (
 	maxRetryAttempts = 3
 	retryBackoff     = time.Second
 
+	// maxListPages caps how many pages DoList will follow. App Store Connect
+	// collections here (certificates, pass type IDs) are small, so this only
+	// guards against a server that keeps handing back a next cursor; it sits far
+	// above any real collection (200 records per page * 500 pages).
+	maxListPages = 500
+
 	// tokenExpiration is the maximum lifetime of a JWT token (20 minutes).
 	tokenExpiration = 20 * time.Minute
 
@@ -272,10 +278,19 @@ func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
 		})
 	}
 
+	return c.retry(ctx, req.Method, req.Endpoint, func(ctx context.Context) (*Response, error) {
+		return c.doOnce(ctx, req, bodyBytes)
+	})
+}
+
+// retry replays send while it fails with a transient server-side error,
+// backing off linearly between attempts. method and endpoint are used only as
+// log context.
+func (c *Client) retry(ctx context.Context, method, endpoint string, send func(context.Context) (*Response, error)) (*Response, error) {
 	var lastErr error
 
 	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
-		resp, err := c.doOnce(ctx, req, bodyBytes)
+		resp, err := send(ctx)
 		if err == nil {
 			return resp, nil
 		}
@@ -289,8 +304,8 @@ func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
 		delay := c.retryBackoff * time.Duration(attempt)
 
 		tflog.Debug(ctx, "Retrying API request after a server error", map[string]interface{}{
-			"method":   req.Method,
-			"endpoint": req.Endpoint,
+			"method":   method,
+			"endpoint": endpoint,
 			"attempt":  attempt,
 			"delay":    delay.String(),
 			"error":    err.Error(),
@@ -304,6 +319,79 @@ func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
 	}
 
 	return nil, lastErr
+}
+
+// DoList performs a GET and transparently follows JSON:API pagination
+// (links.next), accumulating every page's data array into the returned
+// Response. App Store Connect serves list endpoints one page at a time (20 by
+// default, 200 max), so a caller that reads only the first page silently drops
+// every record past it -- a filter lookup can then report a resource as absent
+// when it merely sits on a later page. Callers unmarshal the returned Data
+// exactly as before; it is the concatenation of all pages' items.
+func (c *Client) DoList(ctx context.Context, req Request) (*Response, error) {
+	resp, err := c.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := decodeDataItems(resp.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	next := resp.Links.Next
+
+	for page := 0; next != "" && page < maxListPages; page++ {
+		pageResp, err := c.doPage(ctx, next)
+		if err != nil {
+			return nil, err
+		}
+
+		pageItems, err := decodeDataItems(pageResp.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		items = append(items, pageItems...)
+		next = pageResp.Links.Next
+	}
+
+	if items == nil {
+		items = []json.RawMessage{}
+	}
+
+	combined, err := json.Marshal(items)
+	if err != nil {
+		return nil, fmt.Errorf("failed to combine paginated response: %w", err)
+	}
+
+	resp.Data = combined
+	resp.Links = Links{}
+
+	return resp, nil
+}
+
+// doPage fetches a single pagination URL (an absolute links.next value),
+// applying the same transient-error retry policy as Do.
+func (c *Client) doPage(ctx context.Context, pageURL string) (*Response, error) {
+	return c.retry(ctx, http.MethodGet, pageURL, func(ctx context.Context) (*Response, error) {
+		return c.doOnceURL(ctx, http.MethodGet, pageURL, nil)
+	})
+}
+
+// decodeDataItems splits a JSON:API data array into its elements. A null or
+// empty body yields no items.
+func decodeDataItems(data json.RawMessage) ([]json.RawMessage, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return nil, nil
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse paginated data array: %w", err)
+	}
+
+	return items, nil
 }
 
 // isRetryable reports whether err is a transient server-side failure. Only 5xx
@@ -332,13 +420,20 @@ func (c *Client) doOnce(ctx context.Context, req Request, bodyBytes []byte) (*Re
 		urlStr += "?" + params.Encode()
 	}
 
+	return c.doOnceURL(ctx, req.Method, urlStr, bodyBytes)
+}
+
+// doOnceURL performs a single request against a fully-formed URL. It backs
+// doOnce (which builds the URL from a Request) and doPage (which is handed an
+// absolute links.next cursor).
+func (c *Client) doOnceURL(ctx context.Context, method, urlStr string, bodyBytes []byte) (*Response, error) {
 	var bodyReader io.Reader
 	if bodyBytes != nil {
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, req.Method, urlStr, bodyReader)
+	httpReq, err := http.NewRequestWithContext(ctx, method, urlStr, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -355,9 +450,8 @@ func (c *Client) doOnce(ctx context.Context, req Request, bodyBytes []byte) (*Re
 	httpReq.Header.Set("Accept", "application/json")
 
 	tflog.Debug(ctx, "Making API request", map[string]interface{}{
-		"method":   req.Method,
-		"endpoint": req.Endpoint,
-		"url":      urlStr,
+		"method": method,
+		"url":    urlStr,
 	})
 
 	// Perform request

--- a/internal/provider/client_pagination_test.go
+++ b/internal/provider/client_pagination_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) TrueTickets, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// idsOf unmarshals a JSON:API data array and returns its ids in order.
+func idsOf(t *testing.T, data json.RawMessage) []string {
+	t.Helper()
+
+	var items []struct {
+		ID string `json:"id"`
+	}
+
+	if err := json.Unmarshal(data, &items); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+
+	ids := make([]string, 0, len(items))
+	for _, it := range items {
+		ids = append(ids, it.ID)
+	}
+
+	return ids
+}
+
+// TestDoListFollowsPagination is the regression guard: the App Store Connect
+// API hands back one page at a time with a links.next cursor. Do reads only the
+// first page (documented here), while DoList walks every page and returns the
+// whole collection. Without the follow, a certificate or pass type ID on a
+// later page is invisible to the provider.
+func TestDoListFollowsPagination(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			next := server.URL + "/certificates?cursor=P2&limit=200"
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"A"}],"links":{"next":%q}}`, next)))
+		case "P2":
+			next := server.URL + "/certificates?cursor=P3&limit=200"
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"B"}],"links":{"next":%q}}`, next)))
+		case "P3":
+			_, _ = w.Write([]byte(`{"data":[{"id":"C"}]}`))
+		default:
+			t.Errorf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+
+	req := Request{
+		Method:   http.MethodGet,
+		Endpoint: "/certificates",
+		Query:    map[string]string{"limit": "200"},
+	}
+
+	// Old single-page read only ever sees the first page -- this is the bug
+	// DoList fixes.
+	single, err := client.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if got := idsOf(t, single.Data); len(got) != 1 || got[0] != "A" {
+		t.Fatalf("Do returned %v, want just [A]", got)
+	}
+
+	// DoList walks the whole collection.
+	all, err := client.DoList(context.Background(), req)
+	if err != nil {
+		t.Fatalf("DoList: %v", err)
+	}
+
+	got := idsOf(t, all.Data)
+	want := []string{"A", "B", "C"}
+
+	if len(got) != len(want) {
+		t.Fatalf("DoList returned %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DoList returned %v, want %v", got, want)
+		}
+	}
+
+	// The accumulated Links must not leak a stale next cursor to the caller.
+	if all.Links.Next != "" {
+		t.Errorf("expected cleared links.next, got %q", all.Links.Next)
+	}
+}
+
+// TestDoListSinglePage covers the common case: one page, no next cursor, no
+// extra round-trips.
+func TestDoListSinglePage(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"A"},{"id":"B"}]}`))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+
+	all, err := client.DoList(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/passTypeIds",
+	})
+	if err != nil {
+		t.Fatalf("DoList: %v", err)
+	}
+
+	if got := idsOf(t, all.Data); len(got) != 2 {
+		t.Fatalf("got %v, want 2 items", got)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected a single request, got %d", got)
+	}
+}
+
+// TestDoListEmpty makes sure an empty collection round-trips as a valid empty
+// JSON array rather than null, so callers unmarshalling into a slice keep
+// working.
+func TestDoListEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+
+	all, err := client.DoList(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/certificates",
+	})
+	if err != nil {
+		t.Fatalf("DoList: %v", err)
+	}
+
+	if string(all.Data) != "[]" {
+		t.Errorf("expected empty array, got %s", all.Data)
+	}
+}
+
+// TestDoListRetriesPageErrors confirms the retry policy that guards the first
+// request also guards each follow-up page fetch: a transient 500 on page two is
+// replayed rather than truncating the collection.
+func TestDoListRetriesPageErrors(t *testing.T) {
+	t.Parallel()
+
+	var page2Calls atomic.Int32
+
+	var server *httptest.Server
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("cursor") == "P2" {
+			if page2Calls.Add(1) < 2 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			_, _ = w.Write([]byte(`{"data":[{"id":"B"}]}`))
+
+			return
+		}
+
+		next := server.URL + "/certificates?cursor=P2"
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"A"}],"links":{"next":%q}}`, next)))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+	client.retryBackoff = time.Millisecond
+
+	all, err := client.DoList(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/certificates",
+	})
+	if err != nil {
+		t.Fatalf("DoList: %v", err)
+	}
+
+	if got := idsOf(t, all.Data); len(got) != 2 {
+		t.Fatalf("got %v, want [A B]", got)
+	}
+
+	if got := page2Calls.Load(); got != 2 {
+		t.Errorf("expected page 2 to be retried once (2 calls), got %d", got)
+	}
+}
+
+// TestDoListStopsAtMaxPages guards against a server that keeps handing back a
+// self-referential cursor: DoList must terminate rather than loop forever.
+func TestDoListStopsAtMaxPages(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	var server *httptest.Server
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		next := server.URL + "/certificates?cursor=LOOP"
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"X"}],"links":{"next":%q}}`, next)))
+	}))
+	defer server.Close()
+
+	client := newRetryTestClient(t, server.URL)
+
+	if _, err := client.DoList(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/certificates",
+	}); err != nil {
+		t.Fatalf("DoList: %v", err)
+	}
+
+	// One initial request plus at most maxListPages follow-ups.
+	if got := calls.Load(); got > int32(maxListPages)+1 {
+		t.Errorf("DoList made %d requests, expected it to stop by %d", got, maxListPages+1)
+	}
+}

--- a/internal/provider/pass_type_id_data_source.go
+++ b/internal/provider/pass_type_id_data_source.go
@@ -167,12 +167,14 @@ func (d *PassTypeIDDataSource) Read(ctx context.Context, req datasource.ReadRequ
 			"identifier": filter.Identifier.ValueString(),
 		})
 
-		// Make the API request to list all Pass Type IDs
-		apiResp, err := d.client.Do(ctx, Request{
+		// Make the API request to list all Pass Type IDs, following pagination
+		// so a match on a later page is not missed.
+		apiResp, err := d.client.DoList(ctx, Request{
 			Method:   http.MethodGet,
 			Endpoint: "/passTypeIds",
 			Query: map[string]string{
 				"filter[identifier]": filter.Identifier.ValueString(),
+				"limit":              "200",
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
This PR proposes following the App Store Connect API's list pagination in the provider's data sources, so `appleappstoreconnect_certificate` and `appleappstoreconnect_pass_type_id` lookups no longer stop at the first page of results. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/430. You can sign in with your GitHub ID to claim ownership of the project.

## What this fixes

The App Store Connect API serves its list endpoints one page at a time (20 records by default, 200 maximum) and returns a `links.next` cursor for the remainder. `Client.Do` never read that cursor, so every list request stopped at the first page and silently dropped the rest of the collection.

The sharpest symptom is in the `appleappstoreconnect_certificate` data source's filter lookup: it listed `/certificates` with no `limit` (so the API's 20-record default), then matched the requested serial number client-side. Any certificate that happened to sit on a later page was reported as `No Certificate found matching the filter criteria` even though it exists in the account. The plural `appleappstoreconnect_certificates` data source capped its query at `limit=200` but had the same missing follow past 200, and the `appleappstoreconnect_pass_type_id` lookup had no page bound at all.

The fix adds `Client.DoList`, which transparently follows `links.next` and accumulates every page's `data` array into the returned `Response`. Callers unmarshal the result exactly as before — it is the concatenation of all pages — so the change is drop-in at each call site. `DoList` reuses the existing transient-error retry policy for each page fetch and bounds the walk so a self-referential cursor cannot loop forever. All three list reads now go through it, and the two that were missing the maximum page size now set it to cut down round-trips.

## How I verified it

Reproduced on the current `main` (`3c0a022`) with a paginated mock server: the existing single-page read returns only the first page.

```
$ go test ./internal/provider/ -run TestReproListTruncation -v
    REPRO: list returned 1 of 2 items: [{ID:CERT_A}] (links.next was ".../certificates?cursor=PAGE2&limit=200")
    REPRO CONFIRMED: got 1 items, want 2 -- pagination not followed
--- FAIL: TestReproListTruncation
```

After the fix, `client_pagination_test.go` covers the whole collection being returned across three pages (this assertion fails against the old single-page read), plus single-page, empty-collection, per-page transient-500 retry, and loop-bound cases. I confirmed the regression test is real by reverting only the follow: `DoList returned [A], want [A B C]`.

Full suite before and after, no new failures:

```
$ go test ./...
ok  github.com/truetickets/terraform-provider-appleappstoreconnect/internal/provider
```

`go vet ./...` and `gofmt -l` are both clean. No public types were removed and `Client.Do` is unchanged, so existing callers and behavior are untouched; `DoList` is purely additive.

## How this was managed

We imported your repository's issues and pull requests into a live agile board and used it to track this work. The specific story for this fix is at https://eastagiletracker.com/projects/430/stories/384727, and the full board (27 stories mapped from your PRs) is at https://eastagiletracker.com/projects/430.

![board](https://raw.githubusercontent.com/eastagiletracker/terraform-provider-appleappstoreconnect/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
